### PR TITLE
Commands: Warn the user before overwriting tournaments

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -162,12 +162,12 @@ let commands = {
 	settournament: function (target, room, user) {
 		if (room instanceof Users.User || !Config.tournaments || !Config.tournaments.includes(room.id) || !user.hasRank(room, '%')) return false;
 		if (room.id in Tournaments.tournamentTimers) {
-			let warned = overwriteWarnings.has(user.id) && overwriteWarnings.get(user.id) === room.id;
+			let warned = overwriteWarnings.has(room.id) && overwriteWarnings.get(room.id) === user.id;
 			if (!warned) {
-				overwriteWarnings.set(user.id, room.id);
+				overwriteWarnings.set(room.id, user.id);
 				return this.say("A tournament has already been scheduled in this room. To overwrite it, please reuse this command.");
 			}
-			overwriteWarnings.delete(user.id);
+			overwriteWarnings.delete(room.id);
 		}
 		let targets = target.split(',');
 		if (targets.length < 2) return this.say(Config.commandCharacter + "settour - tier, time, cap (optional)");

--- a/commands.js
+++ b/commands.js
@@ -123,7 +123,7 @@ let commands = {
 	tournament: function (target, room, user) {
 		if (room instanceof Users.User || !Config.tournaments || !Config.tournaments.includes(room.id)) return;
 		if (!target) {
-			if (!user.hasRank(room, '+')) return false;
+			if (!user.hasRank(room, '+')) return;
 			if (!room.tour) return this.say("I am not currently tracking a tournament in this room.");
 			let info = "``" + room.tour.name + " tournament info``";
 			if (room.tour.startTime) {
@@ -134,7 +134,7 @@ let commands = {
 				return this.say(info + ": " + room.tour.playerCount + " player" + (room.tour.playerCount > 1 ? "s" : ""));
 			}
 		} else {
-			if (!user.hasRank(room, '%')) return false;
+			if (!user.hasRank(room, '%')) return;
 			let targets = target.split(',');
 			let cmd = Tools.toId(targets[0]);
 			let format;
@@ -160,7 +160,7 @@ let commands = {
 	},
 	settour: 'settournament',
 	settournament: function (target, room, user) {
-		if (room instanceof Users.User || !Config.tournaments || !Config.tournaments.includes(room.id) || !user.hasRank(room, '%')) return false;
+		if (room instanceof Users.User || !Config.tournaments || !Config.tournaments.includes(room.id) || !user.hasRank(room, '%')) return;
 		if (room.id in Tournaments.tournamentTimers) {
 			let warned = overwriteWarnings.has(room.id) && overwriteWarnings.get(room.id) === user.id;
 			if (!warned) {
@@ -195,7 +195,7 @@ let commands = {
 	},
 	canceltour: 'canceltournament',
 	canceltournament: function (target, room, user) {
-		if (room instanceof Users.User || !Config.tournaments || !Config.tournaments.includes(room.id) || !user.hasRank(room, '%')) return false;
+		if (room instanceof Users.User || !Config.tournaments || !Config.tournaments.includes(room.id) || !user.hasRank(room, '%')) return;
 		if (!(room.id in Tournaments.tournamentTimers)) return this.say("There is no tournament scheduled for this room.");
 		clearTimeout(Tournaments.tournamentTimers[room.id]);
 		this.say("The scheduled tournament was canceled.");


### PR DESCRIPTION
In the event that a scheduled tournament already exists in the room, the bot will map the user's id to the room's id in the `overwriteWarnings` variable. After that, the bot will request that the user reuse the command to overwrite the existing tournament. This has been tested and works; if you wish to see screenshots, I can provide one.

This also corrects the help message for the settour command; it would show `Config.commandCharacter` *and* Lady Monita's command character at the same time, so it would show something like this: "..settour (...)"