### PR TITLE
Quotes: Prevent commands from being used

### DIFF
--- a/plugins/quotes.js
+++ b/plugins/quotes.js
@@ -56,6 +56,7 @@ let commands = {
 		if (!user.hasRank(room, database.defaultRanks['quotes'])) return;
 		target = target.trim();
 		if (!target) return this.say("Please use the following format: .addquote quote");
+		if (target.startsWith("/") || target.startsWith("!")) return this.say("You can't use a command in your quote.");
 		let quotes = database.quotes;
 		let index = quotes.findIndex(/**@param {string} quote */ quote => Tools.toId(quote) === Tools.toId(target));
 		if (index >= 0) return this.say("That quote already exists.");


### PR DESCRIPTION
Yeah, this was a very big security risk. I'm really dumb for not having seen this sooner, but yeah, it can be used to abuse quite a number of commands - see /roomban, /roomvoice, et cetera. Not something to potentially trust Voices with.